### PR TITLE
feat(config): make first tab of example html optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .DS_Store
 npm-debug.log
+.idea

--- a/assets/bootstrap.css
+++ b/assets/bootstrap.css
@@ -233,6 +233,7 @@ tbody.collapse.in {
 .nav-tabs > li > a {
   line-height: 1.42857143;
   text-decoration: none !important;
+  border-bottom: 4px solid transparent;
 }
 .nav-tabs > li > a:hover {
   text-decoration: none !important;

--- a/index.js
+++ b/index.js
@@ -73,13 +73,8 @@ function template(tpl, id, currentFile, config) {
           });
         });
 
-        // By default show the first tab open
-        var firstTabActive = true;
-
-        // Allow configuration to override defaults
-        if (config.firstTabActive === false) {
-          firstTabActive = false;
-        }
+        // By default show the first tab open, allow override.
+        var firstTabActive = config.firstTabActive === false ? false : true;
 
         // Render the whole styleguide section
         return env.render(path.resolve(__dirname, './templates/website.html'), {

--- a/index.js
+++ b/index.js
@@ -73,6 +73,14 @@ function template(tpl, id, currentFile, config) {
           });
         });
 
+        // By default show the first tab open
+        var firstTabActive = true;
+
+        // Allow configuration to override defaults
+        if (config.firstTabActive === false) {
+          firstTabActive = false;
+        }
+
         // Render the whole styleguide section
         return env.render(path.resolve(__dirname, './templates/website.html'), {
           markup: content.body,
@@ -81,7 +89,8 @@ function template(tpl, id, currentFile, config) {
           styles: styles,
           id: id,
           url: tpl,
-          sizes: config.sizes
+          sizes: config.sizes,
+          firstTabActive: firstTabActive,
         });
       })
       .catch(function logError(err) {

--- a/index.js
+++ b/index.js
@@ -16,7 +16,10 @@ function template(tpl, id, currentFile, config) {
       })
       .then(function processTemplate(data) {
         var content = {};
-        var env = new nunjucks.Environment(new nunjucks.FileSystemLoader(), {
+        var env = new nunjucks.Environment(new nunjucks.FileSystemLoader([
+          process.cwd(),
+          __dirname,
+        ]), {
           autoescape: false
         });
 
@@ -74,7 +77,7 @@ function template(tpl, id, currentFile, config) {
         });
 
         // By default show the first tab open, allow override.
-        var firstTabActive = config.firstTabActive === false ? false : true;
+        var firstTabActive = config.firstTabActive !== false;
 
         // Render the whole styleguide section
         return env.render(path.resolve(__dirname, './templates/website.html'), {

--- a/templates/website.html
+++ b/templates/website.html
@@ -22,9 +22,16 @@
   </div>
   <div class="tabs">
     <ul class="nav nav-tabs">
+        {% if firstTabActive %}
         <li class="active">
             <a href="#{{ id }}markup" data-toggle="tab">HTML</a>
         </li>
+        {% else %}
+        <li>
+          <a href="#{{ id }}markup" data-toggle="tab">HTML</a>
+        </li>
+        {% endif %}
+
         {% if js %}
         <li>
             <a href="#{{ id }}js" data-toggle="tab">JS</a>
@@ -53,9 +60,16 @@
         {% endif %}
     </ul>
     <div class="tab-content">
+        {% if firstTabActive %}
         <div class="tab-pane active" id="{{ id }}markup">
             <pre><code class="lang-html">{{ markup | escape }}</code></pre>
         </div>
+        {% else %}
+        <div class="tab-pane" id="{{ id }}markup">
+          <pre><code class="lang-html">{{ markup | escape }}</code></pre>
+        </div>
+        {% endif %}
+
         {% if js %}
         <div class="tab-pane" id="{{ id }}js">
             <pre><code class="lang-javascript">{{ js | escape }}</code></pre>

--- a/templates/website.html
+++ b/templates/website.html
@@ -54,7 +54,7 @@
       {% endif %}
     </ul>
     <div class="tab-content">
-      <div class="tab-pane{% if firstTabActive %}active{% endif %}" id="{{ id }}markup">
+      <div class="tab-pane{% if firstTabActive %} active{% endif %}" id="{{ id }}markup">
         <pre><code class="lang-html">{{ markup | escape }}</code></pre>
       </div>
 

--- a/templates/website.html
+++ b/templates/website.html
@@ -22,73 +22,67 @@
   </div>
   <div class="tabs">
     <ul class="nav nav-tabs">
-        {% if firstTabActive %}
-        <li class="active">
-            <a href="#{{ id }}markup" data-toggle="tab">HTML</a>
-        </li>
-        {% else %}
-        <li>
-          <a href="#{{ id }}markup" data-toggle="tab">HTML</a>
-        </li>
-        {% endif %}
+      <li {% if firstTabActive %} class="active" {% endif %}>
+        <a href="#{{ id }}markup" data-toggle="tab">HTML</a>
+      </li>
 
-        {% if js %}
-        <li>
-            <a href="#{{ id }}js" data-toggle="tab">JS</a>
-        </li>
-        {% endif %}
-        {% if styles.length > 0 or scripts.length > 0 %}
-        <li role="presentation" class="dropdown">
-          <a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">
-            Sources <span class="caret"></span>
-          </a>
-          <ul class="dropdown-menu">
-            {% if styles.length > 0 %}
-            <li class="dropdown-header">Styles</li>
-            {% for style in styles %}
-            <li><a href="#{{ id }}{{ loop.index }}styles" data-toggle="tab">{{ style.file | escape }}</a></li>
-            {% endfor %}
-            {% endif %}
-            {% if scripts.length > 0 %}
-            <li class="dropdown-header">Scripts</li>
-            {% for script in scripts %}
-            <li><a href="#{{ id }}{{ loop.index }}-scripts" data-toggle="tab">{{ script.file | escape }}</a></li>
-            {% endfor %}
-            {% endif %}
-          </ul>
-        </li>
-        {% endif %}
+      {% if js %}
+      <li>
+        <a href="#{{ id }}js" data-toggle="tab">JS</a>
+      </li>
+      {% endif %}
+      {% if styles.length > 0 or scripts.length > 0 %}
+      <li role="presentation" class="dropdown">
+        <a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">
+          Sources <span class="caret"></span>
+        </a>
+        <ul class="dropdown-menu">
+          {% if styles.length > 0 %}
+          <li class="dropdown-header">Styles</li>
+          {% for style in styles %}
+          <li><a href="#{{ id }}{{ loop.index }}styles" data-toggle="tab">{{ style.file | escape }}</a></li>
+          {% endfor %}
+          {% endif %}
+          {% if scripts.length > 0 %}
+          <li class="dropdown-header">Scripts</li>
+          {% for script in scripts %}
+          <li><a href="#{{ id }}{{ loop.index }}-scripts" data-toggle="tab">{{ script.file | escape }}</a></li>
+          {% endfor %}
+          {% endif %}
+        </ul>
+      </li>
+      {% endif %}
     </ul>
     <div class="tab-content">
-        {% if firstTabActive %}
-        <div class="tab-pane active" id="{{ id }}markup">
-            <pre><code class="lang-html">{{ markup | escape }}</code></pre>
-        </div>
-        {% else %}
-        <div class="tab-pane" id="{{ id }}markup">
-          <pre><code class="lang-html">{{ markup | escape }}</code></pre>
-        </div>
-        {% endif %}
+      {% if firstTabActive %}
+      <div class="tab-pane active" id="{{ id }}markup">
+        <pre><code class="lang-html">{{ markup | escape }}</code></pre>
+      </div>
+      {% else %}
+      <div class="tab-pane" id="{{ id }}markup">
+        <pre><code class="lang-html">{{ markup | escape }}</code></pre>
+      </div>
+      {% endif %}
 
-        {% if js %}
-        <div class="tab-pane" id="{{ id }}js">
-            <pre><code class="lang-javascript">{{ js | escape }}</code></pre>
-        </div>
-        {% endif %}
-        {% if styles.length > 0%}
-        {% for style in styles %}
-        <div class="tab-pane" id="{{ id }}{{ loop.index }}styles">
-            <pre><code class="lang-scss">{{ style.content | escape }}</code></pre>
-        </div>
-        {% endfor %}
-        {% endif %}
-        {% if scripts.length > 0%}
-        {% for script in scripts %}
-        <div class="tab-pane" id="{{ id }}{{ loop.index }}-scripts">
-            <pre><code class="lang-javascript">{{ script.content | escape }}</code></pre>
-        </div>
-        {% endfor %}
-        {% endif %}
+      {% if js %}
+      <div class="tab-pane" id="{{ id }}js">
+        <pre><code class="lang-javascript">{{ js | escape }}</code></pre>
+      </div>
+      {% endif %}
+      {% if styles.length > 0%}
+      {% for style in styles %}
+      <div class="tab-pane" id="{{ id }}{{ loop.index }}styles">
+        <pre><code class="lang-scss">{{ style.content | escape }}</code></pre>
+      </div>
+      {% endfor %}
+      {% endif %}
+      {% if scripts.length > 0%}
+      {% for script in scripts %}
+      <div class="tab-pane" id="{{ id }}{{ loop.index }}-scripts">
+        <pre><code class="lang-javascript">{{ script.content | escape }}</code></pre>
+      </div>
+      {% endfor %}
+      {% endif %}
     </div>
   </div>
 </div>

--- a/templates/website.html
+++ b/templates/website.html
@@ -22,7 +22,7 @@
   </div>
   <div class="tabs">
     <ul class="nav nav-tabs">
-      <li {% if firstTabActive %} class="active" {% endif %}>
+      <li{% if firstTabActive %} class="active"{% endif %}>
         <a href="#{{ id }}markup" data-toggle="tab">HTML</a>
       </li>
 
@@ -54,15 +54,9 @@
       {% endif %}
     </ul>
     <div class="tab-content">
-      {% if firstTabActive %}
-      <div class="tab-pane active" id="{{ id }}markup">
+      <div class="tab-pane{% if firstTabActive %}active{% endif %}" id="{{ id }}markup">
         <pre><code class="lang-html">{{ markup | escape }}</code></pre>
       </div>
-      {% else %}
-      <div class="tab-pane" id="{{ id }}markup">
-        <pre><code class="lang-html">{{ markup | escape }}</code></pre>
-      </div>
-      {% endif %}
 
       {% if js %}
       <div class="tab-pane" id="{{ id }}js">


### PR DESCRIPTION
Sometimes the contents of the first tab/tab pane with example html is really huge.
This is adding a configuration option to not show these by default, so that the user can selectively open the tab pane and take the example markup when needed.

This is an example of long contents:
![sg-folded](https://cloud.githubusercontent.com/assets/1923476/20010909/231a1dd4-a2aa-11e6-819a-2dfb8281fee2.png)

Then, when the tab of HTML is clicked, it unfolds and focuses: (on a very long thing)
![sg-unfolded](https://cloud.githubusercontent.com/assets/1923476/20010926/32a0c17c-a2aa-11e6-8cd3-f26f40bd3360.png)
